### PR TITLE
chore: Add rust peerdas kzg library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing",
+ "rand_core",
+ "serde",
+ "subtle",
+]
+
+[[package]]
 name = "bollard-stubs"
 version = "1.42.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1529,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_bls12_381"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=8bafeda8d969cf8c8887aab2eaf3ccba37201abf#8bafeda8d969cf8c8887aab2eaf3ccba37201abf"
+dependencies = [
+ "blst",
+ "blstrs",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing",
+ "rayon",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_erasure_codes"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=8bafeda8d969cf8c8887aab2eaf3ccba37201abf#8bafeda8d969cf8c8887aab2eaf3ccba37201abf"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_polynomial",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_polynomial"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=8bafeda8d969cf8c8887aab2eaf3ccba37201abf#8bafeda8d969cf8c8887aab2eaf3ccba37201abf"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+]
+
+[[package]]
+name = "crate_crypto_kzg_multi_open_fk20"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=8bafeda8d969cf8c8887aab2eaf3ccba37201abf#8bafeda8d969cf8c8887aab2eaf3ccba37201abf"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_polynomial",
+ "hex",
+ "rayon",
 ]
 
 [[package]]
@@ -2212,6 +2269,21 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
+]
+
+[[package]]
+name = "eip7594"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=8bafeda8d969cf8c8887aab2eaf3ccba37201abf#8bafeda8d969cf8c8887aab2eaf3ccba37201abf"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_erasure_codes",
+ "crate_crypto_kzg_multi_open_fk20",
+ "hex",
+ "rayon",
+ "rust-embed",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2982,6 +3054,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec 1.0.1",
  "rand_core",
  "subtle",
 ]
@@ -3422,7 +3495,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -4061,6 +4136,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e11569346406931d20276cc460215ee2826e7cad43aa986999cb244dd7adb0"
+dependencies = [
+ "include-flate-codegen-exports",
+ "lazy_static",
+ "libflate 1.4.0",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a7d6e1419fa3129eb0802b4c99603c0d425c79fb5d76191d5a20d0ab0d664e8"
+dependencies = [
+ "libflate 1.4.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "include-flate-codegen-exports"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75657043ffe3d8280f1cb8aef0f505532b392ed7758e0baeac22edadcee31a03"
+dependencies = [
+ "include-flate-codegen",
+ "proc-macro-hack",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4306,6 +4415,7 @@ dependencies = [
  "arbitrary",
  "c-kzg",
  "derivative",
+ "eip7594",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
@@ -4397,6 +4507,17 @@ checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libflate"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
+dependencies = [
+ "adler32",
+ "crc32fast",
+ "libflate_lz77 1.2.0",
+]
+
+[[package]]
+name = "libflate"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
@@ -4405,7 +4526,16 @@ dependencies = [
  "core2",
  "crc32fast",
  "dary_heap",
- "libflate_lz77",
+ "libflate_lz77 2.1.0",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
+dependencies = [
+ "rle-decode-fast",
 ]
 
 [[package]]
@@ -5910,6 +6040,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6418,6 +6557,12 @@ checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
  "toml_edit 0.20.7",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -7058,6 +7203,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
+dependencies = [
+ "include-flate",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.60",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
+dependencies = [
+ "sha2 0.10.8",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7428,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.200"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -7457,9 +7637,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.200"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7862,7 +8042,7 @@ checksum = "75062c2738b82cd45ae633623caae3393f43eb00aada1dc2d3ebe88db6b0db9b"
 dependencies = [
  "chrono",
  "libc",
- "libflate",
+ "libflate 2.1.0",
  "once_cell",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ clap = { version = "4.5.4", features = ["cargo", "wrap_help"] }
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "114fa0382990e9b74b1f90f3b0dc5f97c2f8a7ad" }
+eip7594 = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "8bafeda8d969cf8c8887aab2eaf3ccba37201abf" }
 compare_fields_derive = { path = "common/compare_fields_derive" }
 criterion = "0.3"
 delay_map = "0.3"

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,4 +1,4 @@
-use kzg::{Blob as KzgBlob, Bytes48, Cell as KzgCell, Error as KzgError, Kzg};
+use kzg::{Blob as KzgBlob, Bytes48, CellRef as KzgCellRef, Error as KzgError, Kzg};
 use std::sync::Arc;
 use types::data_column_sidecar::Cell;
 use types::{Blob, DataColumnSidecar, EthSpec, Hash256, KzgCommitment, KzgProof};
@@ -11,8 +11,11 @@ fn ssz_blob_to_crypto_blob<E: EthSpec>(blob: &Blob<E>) -> Result<KzgBlob, KzgErr
 
 /// Converts a cell ssz List object to an array to be used with the kzg
 /// crypto library.
-fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCell, KzgError> {
-    KzgCell::from_bytes(cell.as_ref()).map_err(Into::into)
+fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCellRef, KzgError> {
+    let cell_bytes: &[u8] = cell.as_ref();
+    Ok(cell_bytes
+        .try_into()
+        .expect("expected cell to have size {BYTES_PER_CELL}. This should be guaranteed by the `FixedVector type"))
 }
 
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -9,7 +9,7 @@ use bls::Signature;
 use derivative::Derivative;
 #[cfg_attr(test, double)]
 use kzg::Kzg;
-use kzg::{Blob as KzgBlob, Cell as KzgCell, Error as KzgError};
+use kzg::{Blob as KzgBlob, CellRef as KzgCellRef, Error as KzgError};
 use kzg::{KzgCommitment, KzgProof};
 use merkle_proof::verify_merkle_proof;
 #[cfg(test)]
@@ -144,11 +144,7 @@ impl<E: EthSpec> DataColumnSidecar<E> {
                         .ok_or(DataColumnSidecarError::InconsistentArrayLength(format!(
                             "Missing blob cell at index {col}"
                         )))?;
-                let cell: Vec<u8> = cell
-                    .into_inner()
-                    .into_iter()
-                    .flat_map(|data| (*data).into_iter())
-                    .collect();
+                let cell: Vec<u8> = cell.to_vec();
                 let cell = Cell::<E>::from(cell);
 
                 let proof = blob_cell_proofs.get(col).ok_or(
@@ -214,7 +210,7 @@ impl<E: EthSpec> DataColumnSidecar<E> {
         let blob_cells_and_proofs_vec = (0..num_of_blobs)
             .into_par_iter()
             .map(|row_index| {
-                let mut cells: Vec<KzgCell> = vec![];
+                let mut cells: Vec<KzgCellRef> = vec![];
                 let mut cell_ids: Vec<u64> = vec![];
                 for data_column in data_columns {
                     let cell = data_column.column.get(row_index).ok_or(
@@ -240,11 +236,7 @@ impl<E: EthSpec> DataColumnSidecar<E> {
                     .ok_or(KzgError::InconsistentArrayLength(format!(
                         "Missing blob cell at index {col}"
                     )))?;
-                let cell: Vec<u8> = cell
-                    .into_inner()
-                    .into_iter()
-                    .flat_map(|data| (*data).into_iter())
-                    .collect();
+                let cell: Vec<u8> = cell.to_vec();
                 let cell = Cell::<E>::from(cell);
 
                 let proof = blob_cell_proofs
@@ -393,8 +385,11 @@ impl From<SszError> for DataColumnSidecarError {
 
 /// Converts a cell ssz List object to an array to be used with the kzg
 /// crypto library.
-fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCell, KzgError> {
-    KzgCell::from_bytes(cell.as_ref()).map_err(Into::into)
+fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCellRef, KzgError> {
+    let cell_bytes: &[u8] = cell.as_ref();
+    Ok(cell_bytes
+        .try_into()
+        .expect("expected cell to have size {BYTES_PER_CELL}. This should be guaranteed by the `FixedVector type"))
 }
 
 #[cfg(test)]

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,4 +17,5 @@ ethereum_serde_utils = { workspace = true }
 hex = { workspace = true }
 ethereum_hashing = { workspace = true }
 c-kzg = { workspace = true }
+eip7594 = { workspace = true }
 mockall = { workspace = true }

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -179,7 +179,7 @@ impl Kzg {
             .map_err(Error::ProverKZG)?;
 
         // Convert the proof type to a c-kzg proof type
-        let c_kzg_proof = proofs.map(|proof| KzgProof(proof));
+        let c_kzg_proof = proofs.map(KzgProof);
         Ok((cells, c_kzg_proof))
     }
 
@@ -201,11 +201,11 @@ impl Kzg {
 
         let proofs: Vec<PeerDASBytes48> = kzg_proofs
             .iter()
-            .map(|proof| proof.as_ref().try_into().unwrap())
+            .map(|proof| proof.as_ref())
             .collect();
         let commitments: Vec<PeerDASBytes48> = kzg_commitments
             .iter()
-            .map(|commitment| commitment.as_ref().try_into().unwrap())
+            .map(|commitment| commitment.as_ref())
             .collect();
         let verification_result = self.context.verifier_ctx().verify_cell_kzg_proof_batch(
             commitments.to_vec(),
@@ -235,7 +235,7 @@ impl Kzg {
             .map_err(Error::ProverKZG)?;
 
         // Convert the proof type to a c-kzg proof type
-        let c_kzg_proof = proofs.map(|proof| KzgProof(proof));
+        let c_kzg_proof = proofs.map(KzgProof);
         Ok((cells, c_kzg_proof))
     }
 }

--- a/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
@@ -62,12 +62,9 @@ impl<E: EthSpec> Case for KZGComputeCellsAndKZGProofs<E> {
                 .ok()
         });
 
-        compare_result::<
-            (
-                Box<[Cell; CELLS_PER_EXT_BLOB]>,
-                Box<[KzgProof; CELLS_PER_EXT_BLOB]>,
-            ),
-            _,
-        >(&cells_and_proofs, &expected)
+        compare_result::<([Cell; CELLS_PER_EXT_BLOB], [KzgProof; CELLS_PER_EXT_BLOB]), _>(
+            &cells_and_proofs,
+            &expected,
+        )
     }
 }

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -40,8 +40,9 @@ pub fn parse_cell(cell: &str) -> Result<Cell, Error> {
     hex::decode(strip_0x(cell)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse cell: {:?}", e)))
         .and_then(|bytes| {
-            Cell::from_bytes(bytes.as_ref())
-                .map_err(|e| Error::FailedToParseTest(format!("Failed to parse proof: {:?}", e)))
+            bytes
+                .try_into()
+                .map_err(|e| Error::FailedToParseTest(format!("Failed to parse cell: {:?}", e)))
         })
 }
 

--- a/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
@@ -56,12 +56,8 @@ impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
             parse_input(&self.input).and_then(|(cells, proofs, coordinates, commitments)| {
                 let proofs: Vec<Bytes48> = proofs.iter().map(|&proof| proof.into()).collect();
                 let commitments: Vec<Bytes48> = commitments.iter().map(|&c| c.into()).collect();
-                match KZG.verify_cell_proof_batch(
-                    cells.as_slice(),
-                    &proofs,
-                    &coordinates,
-                    &commitments,
-                ) {
+                let cells = cells.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
+                match KZG.verify_cell_proof_batch(&cells, &proofs, &coordinates, &commitments) {
                     Ok(_) => Ok(true),
                     Err(KzgError::KzgVerificationFailed) => Ok(false),
                     Err(e) => Err(Error::InternalError(format!(


### PR DESCRIPTION
## Issue Addressed

This adds the rust peerdas-kzg library. This leaves the auditted c-kzg code intact, so that the DAS branch can be merged into unstable.

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
