### PR TITLE
ethproofs: debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11438,6 +11438,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.12",
  "tokio",
+ "tracing",
  "types",
 ]
 

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -295,9 +295,10 @@ impl<E: EthSpec> PubsubMessage<E> {
                     }
                     GossipKind::ExecutionProof => {
                         match fork_context.get_fork_from_context_bytes(gossip_topic.fork_digest) {
+                            // TODO(ethproofs): Changed to Electra for the Ethproofs demo testing.
                             // TODO(zkproofs): we don't have the ChainSpec here, so if we change this to
-                            // be for gloas, then we should change it here too
-                            Some(fork) if fork.fulu_enabled() => {
+                            // be for gloas, then we should change it here too.
+                            Some(fork) if fork.electra_enabled() => {
                                 let execution_proof = Arc::new(
                                     ExecutionProof::from_ssz_bytes(data)
                                         .map_err(|e| format!("{:?}", e))?,

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -220,6 +220,7 @@ pub struct ChainSpec {
      */
     /// Whether zkVM mode is enabled via CLI flag --activate-zkvm.
     /// When true, the node will subscribe to execution proof gossip, verify proofs,
+    /// TODO(ethproofs): Changed to Electra fork epoch.
     /// and optionally generate proofs. zkVM activates at the Fulu fork.
     /// Unlike other forks, this is not a network-wide activation but a per-node opt-in.
     pub zkvm_enabled: bool,
@@ -495,12 +496,14 @@ impl ChainSpec {
         self.zkvm_enabled
     }
 
+    /// TODO(ethproofs): Changed to Electra fork epoch.
+    ///
     /// Returns the epoch at which zkVM activates.
     /// Currently uses Fulu fork epoch.
     /// Returns None if zkVM is disabled or Fulu is not scheduled.
     pub fn zkvm_fork_epoch(&self) -> Option<Epoch> {
         if self.zkvm_enabled {
-            self.fulu_fork_epoch
+            self.electra_fork_epoch
         } else {
             None
         }
@@ -512,9 +515,11 @@ impl ChainSpec {
             .is_some_and(|zkvm_fork_epoch| epoch >= zkvm_fork_epoch)
     }
 
+    /// TODO(ethproofs): Changed to Electra fork epoch.
+    ///
     /// Returns true if zkVM mode can be used at the given fork.
     pub fn is_zkvm_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        self.is_zkvm_enabled() && fork_name.fulu_enabled()
+        self.is_zkvm_enabled() && fork_name.electra_enabled()
     }
 
     /// Returns the minimum number of execution proofs required.

--- a/zkvm_execution_layer/Cargo.toml
+++ b/zkvm_execution_layer/Cargo.toml
@@ -10,6 +10,7 @@ hashbrown = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 thiserror = "2"
+tracing = { workspace = true }
 types = { path = "../consensus/types" }
 execution_layer = { path = "../beacon_node/execution_layer" }
 

--- a/zkvm_execution_layer/src/dummy_proof_gen.rs
+++ b/zkvm_execution_layer/src/dummy_proof_gen.rs
@@ -2,6 +2,7 @@ use crate::proof_generation::{ProofGenerationError, ProofGenerationResult, Proof
 use async_trait::async_trait;
 use std::time::Duration;
 use tokio::time::sleep;
+use tracing::debug;
 use types::{ExecutionBlockHash, ExecutionProof, ExecutionProofId, Hash256, Slot};
 
 /// Dummy proof generator for testing
@@ -39,6 +40,11 @@ impl ProofGenerator for DummyProofGenerator {
         payload_hash: &ExecutionBlockHash,
         block_root: &Hash256,
     ) -> ProofGenerationResult<ExecutionProof> {
+        debug!(
+            "[Ethproofs] DummyProofGenerator::generate called for proof_id={}, slot={}, block_hash={}",
+            self.proof_id, slot, payload_hash
+        );
+
         // Simulate proof generation work
         if !self.generation_delay.is_zero() {
             sleep(self.generation_delay).await;

--- a/zkvm_execution_layer/src/dummy_proof_verifier.rs
+++ b/zkvm_execution_layer/src/dummy_proof_verifier.rs
@@ -1,5 +1,6 @@
 use crate::proof_verification::{ProofVerificationResult, ProofVerifier, VerificationError};
 use std::time::Duration;
+use tracing::debug;
 use types::{ExecutionProof, ExecutionProofId};
 
 /// Dummy proof verifier for testing
@@ -31,6 +32,11 @@ impl DummyVerifier {
 
 impl ProofVerifier for DummyVerifier {
     fn verify(&self, proof: &ExecutionProof) -> ProofVerificationResult<bool> {
+        debug!(
+            "[Ethproofs] DummyVerifier::verify called for proof_id={}, block_hash={}",
+            proof.proof_id, proof.block_hash
+        );
+
         // Check that the proof is for the correct subnet
         if proof.proof_id != self.proof_id {
             return Err(VerificationError::UnsupportedProofID(proof.proof_id));


### PR DESCRIPTION
- Changes hardcoded fulu fork for the demo
- Adds debug log to confirm dummy_proof_gen `generate()`
- Adds debug log to confirm dummy_proof_verifier `verify()`
